### PR TITLE
去除json中字段下划线的警告

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -1,4 +1,4 @@
-rzd
+
 语言: [English](README.md) | [中文简体](README-ZH.md)
 
 

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -1,4 +1,4 @@
-
+rzd
 语言: [English](README.md) | [中文简体](README-ZH.md)
 
 

--- a/bin/json_model.dart
+++ b/bin/json_model.dart
@@ -4,7 +4,7 @@ import 'package:args/args.dart';
 import 'package:path/path.dart' as path;
 import 'build_runner.dart' as br;
 
-const tpl="import 'package:json_annotation/json_annotation.dart';\n%t\npart '%s.g.dart';\n\n@JsonSerializable()\nclass %s {\n    %s();\n\n    %s\n    factory %s.fromJson(Map<String,dynamic> json) => _\$%sFromJson(json);\n    Map<String, dynamic> toJson() => _\$%sToJson(this);\n}\n";
+const tpl="// ignore_for_file: non_constant_identifier_names\nimport 'package:json_annotation/json_annotation.dart';\n%t\npart '%s.g.dart';\n\n@JsonSerializable()\nclass %s {\n    %s();\n\n    %s\n    factory %s.fromJson(Map<String,dynamic> json) => _\$%sFromJson(json);\n    Map<String, dynamic> toJson() => _\$%sToJson(this);\n}\n";
 
 void main(List<String> args) {
   String src;

--- a/bin/json_model.dart
+++ b/bin/json_model.dart
@@ -4,7 +4,7 @@ import 'package:args/args.dart';
 import 'package:path/path.dart' as path;
 import 'build_runner.dart' as br;
 
-const tpl="// ignore_for_file: non_constant_identifier_names\nimport 'package:json_annotation/json_annotation.dart';\n%t\npart '%s.g.dart';\n\n@JsonSerializable()\nclass %s {\n    %s();\n\n    %s\n    factory %s.fromJson(Map<String,dynamic> json) => _\$%sFromJson(json);\n    Map<String, dynamic> toJson() => _\$%sToJson(this);\n}\n";
+const tpl="// ignore_for_file: non_constant_identifier_names\n// ignore_for_file: camel_case_types\nimport 'package:json_annotation/json_annotation.dart';\n%t\npart '%s.g.dart';\n\n@JsonSerializable()\nclass %s {\n    %s();\n\n    %s\n    factory %s.fromJson(Map<String,dynamic> json) => _\$%sFromJson(json);\n    Map<String, dynamic> toJson() => _\$%sToJson(this);\n}\n";
 
 void main(List<String> args) {
   String src;

--- a/lib/index.dart
+++ b/lib/index.dart
@@ -4,7 +4,7 @@ import 'package:args/args.dart';
 import 'package:path/path.dart' as path;
 import 'build_runner.dart' as br;
 
-const tpl="import 'package:json_annotation/json_annotation.dart';\n%t\npart '%s.g.dart';\n\n@JsonSerializable()\nclass %s {\n    %s();\n\n    %s\n    factory %s.fromJson(Map<String,dynamic> json) => _\$%sFromJson(json);\n    Map<String, dynamic> toJson() => _\$%sToJson(this);\n}\n";
+const tpl="// ignore_for_file: non_constant_identifier_names\nimport 'package:json_annotation/json_annotation.dart';\n%t\npart '%s.g.dart';\n\n@JsonSerializable()\nclass %s {\n    %s();\n\n    %s\n    factory %s.fromJson(Map<String,dynamic> json) => _\$%sFromJson(json);\n    Map<String, dynamic> toJson() => _\$%sToJson(this);\n}\n";
 
 void run(List<String> args) {
   String src;

--- a/lib/index.dart
+++ b/lib/index.dart
@@ -4,7 +4,7 @@ import 'package:args/args.dart';
 import 'package:path/path.dart' as path;
 import 'build_runner.dart' as br;
 
-const tpl="// ignore_for_file: non_constant_identifier_names\nimport 'package:json_annotation/json_annotation.dart';\n%t\npart '%s.g.dart';\n\n@JsonSerializable()\nclass %s {\n    %s();\n\n    %s\n    factory %s.fromJson(Map<String,dynamic> json) => _\$%sFromJson(json);\n    Map<String, dynamic> toJson() => _\$%sToJson(this);\n}\n";
+const tpl="// ignore_for_file: non_constant_identifier_names\n// ignore_for_file: camel_case_types\nimport 'package:json_annotation/json_annotation.dart';\n%t\npart '%s.g.dart';\n\n@JsonSerializable()\nclass %s {\n    %s();\n\n    %s\n    factory %s.fromJson(Map<String,dynamic> json) => _\$%sFromJson(json);\n    Map<String, dynamic> toJson() => _\$%sToJson(this);\n}\n";
 
 void run(List<String> args) {
   String src;

--- a/model.tpl
+++ b/model.tpl
@@ -1,4 +1,5 @@
-// ignore_for_file: non_constant_identifier_names\n
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: camel_case_types
 import 'package:json_annotation/json_annotation.dart';
 %t
 part '%s.g.dart';

--- a/model.tpl
+++ b/model.tpl
@@ -1,3 +1,4 @@
+// ignore_for_file: non_constant_identifier_names\n
 import 'package:json_annotation/json_annotation.dart';
 %t
 part '%s.g.dart';


### PR DESCRIPTION
json字段内如果必须有下划线的字段，生成的文件会有dart警告。
// ignore_for_file: non_constant_identifier_names
// ignore_for_file: camel_case_types
文件头添加这两行注释可以避免恼人的警告。